### PR TITLE
Fix path on require for cielo tritoq autoloader

### DIFF
--- a/upload/system/library/cielo.php
+++ b/upload/system/library/cielo.php
@@ -1,4 +1,4 @@
 <?php
-require_once(dirname(__FILE__) . '/Tritoq/TritoqAutoloader.php');
+require_once(DIR_SYSTEM . '/library/Tritoq/TritoqAutoloader.php');
 
 TritoqAutoloader::register();


### PR DESCRIPTION
Fixing the require_once error:

```
require_once(/home/username/public_html/vqmod/vqcache/Tritoq/TritoqAutoloader.php): failed to open stream: No such file or directory in /home/username/public_html/vqmod/vqcache/vq2-system_library_cielo.php on line 2
```
